### PR TITLE
Fix cocktails router DB usage

### DIFF
--- a/backend/routers/cocktails.py
+++ b/backend/routers/cocktails.py
@@ -1,54 +1,47 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException, Query
 from typing import List
 from models import Cocktail
-import random
+from sqlalchemy.orm import Session
+from sqlalchemy import text
 from database import get_db
-from fastapi import Query
-from fastapi import Request
+import random
 
 router = APIRouter()
 
 @router.get("/cocktails", response_model=List[Cocktail])
-def get_cocktails():
-    conn = get_db()
-    cursor = conn.cursor()
-
-    # ✅ Select all fields now that model is extended
-    rows = cursor.execute("SELECT * FROM drinks LIMIT 50").fetchall()
-    conn.close()
-
-    return [dict(row) for row in rows]
+def get_cocktails(db: Session = Depends(get_db)):
+    rows = db.execute(text("SELECT * FROM drinks LIMIT 50")).fetchall()
+    return [dict(row._mapping) for row in rows]
 
 @router.get("/cocktails/{id}", response_model=Cocktail)
-def get_cocktail_by_id(id: int):
-    conn = get_db()
-    row = conn.execute("SELECT * FROM drinks WHERE id = ?", (id,)).fetchone()
-    conn.close()
+def get_cocktail_by_id(id: int, db: Session = Depends(get_db)):
+    row = db.execute(
+        text("SELECT * FROM drinks WHERE id = :id"),
+        {"id": id},
+    ).fetchone()
     if row is None:
-        return {"error": "Cocktail not found"}
-    return dict(row)
+        raise HTTPException(status_code=404, detail="Cocktail not found")
+    return dict(row._mapping)
 
 @router.get("/search", response_model=List[Cocktail])
-def search_cocktails(query: str = Query(..., min_length=1)):
-    conn = get_db()
-    cursor = conn.cursor()
-
-    # Check name match
+def search_cocktails(query: str = Query(..., min_length=1), db: Session = Depends(get_db)):
     query_like = f"%{query}%"
-    name_matches = cursor.execute("""
+    name_matches = db.execute(text(
+        """
         SELECT id, strDrink, strCategory, strAlcoholic, strGlass, strDrinkThumb
         FROM drinks
-        WHERE strDrink LIKE ?
-    """, (query_like,)).fetchall()
+        WHERE strDrink LIKE :qlike
+        """
+    ), {"qlike": query_like}).fetchall()
 
-    # Check ingredient matches
-    ingredient_matches = cursor.execute(f"""
+    ingredient_conditions = " OR ".join([f"strIngredient{i} LIKE :qlike" for i in range(1, 16)])
+    ingredient_matches = db.execute(text(
+        f"""
         SELECT id, strDrink, strCategory, strAlcoholic, strGlass, strDrinkThumb
         FROM drinks
-        WHERE {" OR ".join([f"strIngredient{i} LIKE ?" for i in range(1, 16)])}
-    """, tuple([query_like] * 15)).fetchall()
-
-    conn.close()
+        WHERE {ingredient_conditions}
+        """
+    ), {"qlike": query_like}).fetchall()
 
     # Combine and deduplicate by cocktail ID
     seen_ids = set()
@@ -57,19 +50,18 @@ def search_cocktails(query: str = Query(..., min_length=1)):
     for row in name_matches + ingredient_matches:
         if row["id"] not in seen_ids:
             seen_ids.add(row["id"])
-            all_results.append(dict(row))
+            all_results.append(dict(row._mapping))
 
     return all_results
 
 @router.get("/available", response_model=List[Cocktail])
-def get_available_cocktails(has: str = Query(..., description="Comma-separated list of ingredients")):
+def get_available_cocktails(
+    has: str = Query(..., description="Comma-separated list of ingredients"),
+    db: Session = Depends(get_db),
+):
     user_ingredients = [i.strip().lower() for i in has.split(",")]
 
-    conn = get_db()
-    cursor = conn.cursor()
-
-    rows = cursor.execute("SELECT * FROM drinks").fetchall()
-    conn.close()
+    rows = db.execute(text("SELECT * FROM drinks")).fetchall()
 
     results = []
     for row in rows:
@@ -80,30 +72,30 @@ def get_available_cocktails(has: str = Query(..., description="Comma-separated l
         ]
 
         if all(ing in user_ingredients for ing in ingredients):
-            results.append(dict(row))
+            results.append(dict(row._mapping))
 
     return results
 
 import random
 
 @router.get("/random", response_model=Cocktail)
-def get_random_cocktail():
-    conn = get_db()
-    cursor = conn.cursor()
-
+def get_random_cocktail(db: Session = Depends(get_db)):
     # Get total number of drinks
-    count = cursor.execute("SELECT COUNT(*) FROM drinks").fetchone()[0]
+    count = db.execute(text("SELECT COUNT(*) FROM drinks")).scalar()
 
     # Pick a random offset
     random_offset = random.randint(0, count - 1)
 
     # Get 1 random drink
-    row = cursor.execute("""
-        SELECT id, strDrink, strCategory, strAlcoholic, strGlass, strDrinkThumb
-        FROM drinks
-        LIMIT 1 OFFSET ?
-    """, (random_offset,)).fetchone()
+    row = db.execute(
+        text(
+            """
+            SELECT id, strDrink, strCategory, strAlcoholic, strGlass, strDrinkThumb
+            FROM drinks
+            LIMIT 1 OFFSET :offset
+            """
+        ),
+        {"offset": random_offset},
+    ).fetchone()
 
-    conn.close()
-
-    return dict(row)
+    return dict(row._mapping)


### PR DESCRIPTION
## Summary
- switch cocktails router to use SQLAlchemy sessions properly
- handle 404 when a cocktail id doesn't exist
- update all routes to convert results with `_mapping`

## Testing
- `python -m py_compile backend/routers/cocktails.py`
- `find backend -name '*.py' -print0 | xargs -0 python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_684dffdd352c8327abcc8d7c9b915ad6